### PR TITLE
Fix error that occurred on startup if registry value did not exist

### DIFF
--- a/BSManagerMain.cs
+++ b/BSManagerMain.cs
@@ -231,7 +231,7 @@ namespace BSManager
 
                 using (RegistryKey registryStart = Registry.CurrentUser.OpenSubKey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run", true))
                 {
-                    string _curpath = registryStart.GetValue("BSManager").ToString();
+                    string _curpath = registryStart?.GetValue("BSManager")?.ToString();
                     if (_curpath == null)
                     {
                         toolStripRunAtStartup.Checked = false;


### PR DESCRIPTION
Fixed an error I was getting on first run because registryStart?.GetValue("BSManager") was null causing ToString() to fail